### PR TITLE
Improve WordPress translation

### DIFF
--- a/include-matomo.php
+++ b/include-matomo.php
@@ -2,7 +2,7 @@
 /* 
 Plugin Name: Include Matomo Tracking, by Jonas Hellmann
 Plugin URI: https://github.com/jonashellmann/include-matomo/
-Description: This plugin includes Matomo into your Wordpress site
+Description: This plugin includes Matomo into your WordPress site
 Version: 1.5.2
 Author: Jonas Hellmann
 Author URI: https://jonas-hellmann.de/en/

--- a/include-matomo.php
+++ b/include-matomo.php
@@ -86,7 +86,7 @@ function include_matomo_settings_page() { ?>
      <?php do_settings_sections( 'include-matomo-settings-group' ); ?>
    <table class="form-table">
     <tr valign="top">
-      <th scope="row">Matomo URL</th>
+      <th scope="row"><?php _e('Matomo URL', 'include-matomo' );?></th>
       <td>
         <input type="text" name="matomo_url" value="<?php echo esc_attr( get_option('matomo_url') ); ?>" />
       </td>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link:
 Tags: matomo, analytics, tracking
 Requires at least: 4.7
 Tested up to: 6.9
-Stable tag: trunk 
+Stable tag: 1.5.2
 Requires PHP: 7.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
This PR fixes a typo + allow translators to translate the stable version (which is 1.5.2, not trunk)
Trunk is the development version